### PR TITLE
Support new net-ssh verify_host_key option

### DIFF
--- a/lib/kitchen/transport/kerberos.rb
+++ b/lib/kitchen/transport/kerberos.rb
@@ -51,7 +51,6 @@ module Kitchen
         opts = {
           logger: logger,
           user_known_hosts_file: "/dev/null",
-          paranoid: false,
           hostname: data[:hostname],
           port: data[:port],
           username: data[:username],
@@ -69,10 +68,20 @@ module Kitchen
 	        auth_methods: %w[gssapi-with-mic]
         }
 
+        opts[verify_host_key_option] = false
+
         opts[:forward_agent] = data[:forward_agent] if data.key?(:forward_agent)
         opts[:verbose] = data[:verbose].to_sym      if data.key?(:verbose)
 
         opts
+      end
+
+      # net-ssh >=4.2 has renamed paranoid option to verify_host_key
+      def verify_host_key_option
+        current_net_ssh = Net::SSH::Version::CURRENT
+        new_option_version = Net::SSH::Version[4, 2, 0]
+
+        current_net_ssh >= new_option_version ? :verify_host_key : :paranoid
       end
     end
   end

--- a/lib/train/transports/kerberos.rb
+++ b/lib/train/transports/kerberos.rb
@@ -56,10 +56,9 @@ module Train::Transports
     # @return [Hash] hash of connection options
     # @api private
     def connection_options(opts)
-      {
+      opts = {
         logger:                 logger,
         user_known_hosts_file:  '/dev/null',
-        paranoid:               false,
         hostname:               opts[:host],
         port:                   opts[:port],
         username:               opts[:user],
@@ -78,7 +77,18 @@ module Train::Transports
         forward_agent:          opts[:forward_agent],
         transport_options:      opts,
       }
+
+      opts[verify_host_key_option] = false
+
+      opts
     end
 
+    # net-ssh >=4.2 has renamed paranoid option to verify_host_key
+    def verify_host_key_option
+      current_net_ssh = Net::SSH::Version::CURRENT
+      new_option_version = Net::SSH::Version[4, 2, 0]
+
+      current_net_ssh >= new_option_version ? :verify_host_key : :paranoid
+    end
   end
 end


### PR DESCRIPTION
`paranoid` option was renamed in net-ssh 2.4 net-ssh/net-ssh#524 . 
This pr implements the same check that was added in test-kitchen/test-kitchen#1285